### PR TITLE
Amend regex for words to look for in parse_output

### DIFF
--- a/lib/guard/phpunit2/formatter.rb
+++ b/lib/guard/phpunit2/formatter.rb
@@ -16,9 +16,9 @@ module Guard
         def parse_output(text)
           results = {
             :tests    => look_for_words_in('(?:Tests:|tests)',    text),
-            :failures => look_for_words_in('Failures:', text),
+            :failures => look_for_words_in('(?:Failures:|failures)', text),
             :errors   => look_for_words_in('Errors:', text),
-            :pending  => look_for_words_in(['Skipped:', 'Incomplete:'], text),
+            :pending  => look_for_words_in(['(?:Skipped:|skipped)', 'Incomplete:'], text),
             :duration => look_for_duration_in(text)
           }
           results.freeze


### PR DESCRIPTION
The output from PHPUnit ~3.7 has lower case 'skipped' and 'failures', this was causing the notification to incorrectly show passing tests when the terminal display fails.

This has only been tested on MacOSX with `terminal-notifier-guard` and `growl` gems