### PR TITLE
Multiple tests paths

### DIFF
--- a/lib/guard/phpunit2/inspector.rb
+++ b/lib/guard/phpunit2/inspector.rb
@@ -18,7 +18,8 @@ module Guard
         def clean(paths)
           paths.uniq!
           paths.compact!
-          populate_test_files()
+          #populate_test_files()
+		  tests_files
           paths = paths.select { |p| test_file?(p) }
           clear_tests_files_list
           paths
@@ -27,7 +28,8 @@ module Guard
         private
 
 
-        def populate_test_files()
+        def tests_files
+        #def populate_test_files()
           @tests_files ||= []
 
           _files = []
@@ -59,10 +61,12 @@ module Guard
         # Scans the tests path and keeps a list of all
         # tests paths.
         #
-        def tests_files
+        #def tests_files
           #Uses the current path for tests_path when unset.
-          @tests_files ||= Dir.glob( File.join(tests_path, '**', '*Test.php') )
-        end
+          #@tests_files ||= Dir.glob( File.join(tests_path, '**', '*Test.php') )
+          #populate_test_files()
+		  #@tests_files
+        #end
 
         # Clears the list of PHPUnit tests.
         #

--- a/lib/guard/phpunit2/inspector.rb
+++ b/lib/guard/phpunit2/inspector.rb
@@ -18,12 +18,34 @@ module Guard
         def clean(paths)
           paths.uniq!
           paths.compact!
+          populate_test_files()
           paths = paths.select { |p| test_file?(p) }
           clear_tests_files_list
           paths
         end
 
         private
+
+
+        def populate_test_files()
+          @tests_files ||= []
+
+          _files = []
+
+          if @tests_files == []
+            if tests_path.is_a? String
+              _files = _files.concat(phpunit_glob(tests_path))
+            elsif tests_path.is_a? Array
+              tests_path.each { |path| _files.concat(phpunit_glob(path)) }
+            end
+          end
+
+          @tests_files = _files
+        end
+
+        def phpunit_glob(path)
+          Dir.glob( File.join(path, '**', '*Test.php') )
+        end
 
         # Checks if the paths is a valid test file.
         #
@@ -38,6 +60,7 @@ module Guard
         # tests paths.
         #
         def tests_files
+          #Uses the current path for tests_path when unset.
           @tests_files ||= Dir.glob( File.join(tests_path, '**', '*Test.php') )
         end
 

--- a/spec/guard/phpunit2/inspector_spec.rb
+++ b/spec/guard/phpunit2/inspector_spec.rb
@@ -1,11 +1,7 @@
 require 'spec_helper'
 
 describe Guard::PHPUnit2::Inspector do
-  before do
-    subject.tests_path = 'spec/fixtures'
-  end
-
-  describe 'clean' do
+  shared_examples 'clean' do
     it 'removes non-tests files' do
       subject.clean(['spec/fixtures/sampleTest.php', 'foo.php']).should == ['spec/fixtures/sampleTest.php']
     end
@@ -29,6 +25,26 @@ describe Guard::PHPUnit2::Inspector do
     it 'frees up the list of tests files' do
       subject.should_receive(:clear_tests_files_list)
       subject.clean(['classTest.php'])
+    end
+  end
+
+  context '(when tests_path is an array)' do
+    before do
+      subject.tests_path = ['spec/fixtures']
+    end
+
+    describe 'clean' do
+      include_examples 'clean'
+    end
+  end
+
+  context '(when tests_path is a string)' do
+    before do
+      subject.tests_path = 'spec/fixtures'
+    end
+
+    describe 'clean' do
+      include_examples 'clean'
     end
   end
 end


### PR DESCRIPTION
This finishes the support for an array in :test_path option. Before, it
half worked, running all tests okay, but watching changes didn't work.

Includes #12, but does not depend on #12.
