### PR TITLE
Feature/guard 2.0 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: jruby
-before_script: 'bundle list'
 notifications:
   email:
     - ramon@codecraft63.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.2
+  - jruby
+matrix:
+  allow_failures:
+    - rvm: jruby
+before_script: 'bundle list'
 notifications:
   email:
     - ramon@codecraft63.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.0.0
   - 2.1.2
   - jruby
+env:
+  global:
+    - "JRUBY_OPTS=-Xcext.enabled=true"
 matrix:
   allow_failures:
     - rvm: jruby

--- a/Gemfile
+++ b/Gemfile
@@ -10,21 +10,21 @@ require 'rbconfig'
 
 platforms :ruby do
   if RbConfig::CONFIG['target_os'] =~ /darwin/i
-    gem 'rb-fsevent', '~> 0.9.1'
-    gem 'growl',      '~> 1.0.3'
+    gem 'rb-fsevent', '>= 0.9.1'
+    gem 'growl',      '>= 1.0.3'
   end
   if RbConfig::CONFIG['target_os'] =~ /linux/i
-    gem 'rb-inotify', '~> 0.8.8'
-    gem 'libnotify',  '~> 0.7.3'
+    gem 'rb-inotify', '>= 0.8.8'
+    gem 'libnotify',  '>= 0.7.3'
   end
 end
 
 platforms :jruby do
   if RbConfig::CONFIG['target_os'] =~ /darwin/i
-    gem 'growl',      '~> 1.0.3'
+    gem 'growl',      '>= 1.0.3'
   end
   if RbConfig::CONFIG['target_os'] =~ /linux/i
-    gem 'rb-inotify', '~> 0.8.8'
-    gem 'libnotify',  '~> 0.7.3'
+    gem 'rb-inotify', '>= 0.8.8'
+    gem 'libnotify',  '>= 0.7.3'
   end
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec', :version => 2, :rvm => ['2.0@guard-phpunit2'] do
+guard 'rspec', :cmd => 'rspec' do
   watch('spec/spec_helper.rb') { 'spec' }
   watch(%r{^spec/.+_spec\.rb})
   watch(%r{^lib/(.+)\.rb})     { |m| "spec/#{m[1]}_spec.rb" }

--- a/guard-phpunit2.gemspec
+++ b/guard-phpunit2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'guard-phpunit2'
 
-  s.add_runtime_dependency 'guard', ['>= 1.1', '< 3.0']
+  s.add_runtime_dependency 'guard', ['>= 2.0', '< 3.0']
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rspec'

--- a/guard-phpunit2.gemspec
+++ b/guard-phpunit2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'guard-phpunit2'
 
-  s.add_runtime_dependency 'guard', ['>= 2.0', '< 3.0']
+  s.add_runtime_dependency 'guard', ['>= 1.1', '< 3.0']
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rspec'

--- a/guard-phpunit2.gemspec
+++ b/guard-phpunit2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'guard-phpunit2'
 
-  s.add_dependency('guard-compat', '~> 1.1')
+  s.add_dependency('guard-compat', '~> 1.2')
 
   s.add_runtime_dependency 'guard', ['>= 2.0', '< 3.0']
 

--- a/guard-phpunit2.gemspec
+++ b/guard-phpunit2.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'guard-phpunit2'
 
+  s.add_dependency('guard-compat', '~> 1.1')
+
   s.add_runtime_dependency 'guard', ['>= 2.0', '< 3.0']
 
   s.add_development_dependency 'bundler'

--- a/lib/guard/phpunit2.rb
+++ b/lib/guard/phpunit2.rb
@@ -1,5 +1,5 @@
 require 'guard'
-require 'guard/plugin'
+require 'guard/guard'
 require 'guard/phpunit2/version'
 
 module Guard
@@ -7,7 +7,7 @@ module Guard
   # The PHPUnit guard gets notified about system
   # events.
   #
-  class PHPUnit2 < Plugin
+  class PHPUnit2 < Guard
 
     autoload :Inspector, 'guard/phpunit2/inspector'
     autoload :Formatter, 'guard/phpunit2/formatter'

--- a/lib/guard/phpunit2.rb
+++ b/lib/guard/phpunit2.rb
@@ -1,5 +1,4 @@
-require 'guard'
-require 'guard/guard'
+require 'guard/compat/plugin'
 require 'guard/phpunit2/version'
 
 module Guard

--- a/lib/guard/phpunit2.rb
+++ b/lib/guard/phpunit2.rb
@@ -7,7 +7,7 @@ module Guard
   # The PHPUnit guard gets notified about system
   # events.
   #
-  class PHPUnit2 < Guard
+  class PHPUnit2 < Plugin
 
     autoload :Inspector, 'guard/phpunit2/inspector'
     autoload :Formatter, 'guard/phpunit2/formatter'
@@ -36,10 +36,10 @@ module Guard
     # @option options [String] :cli The CLI arguments passed to phpunit
     # @option options [String] :tests_path the path where all tests exist
     #
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       defaults = DEFAULT_OPTIONS.clone
       @options = defaults.merge(options)
-      super(watchers, @options)
+      super(@options)
 
       @failed_paths     = []
       @previous_failed = false

--- a/lib/guard/phpunit2.rb
+++ b/lib/guard/phpunit2.rb
@@ -1,5 +1,5 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'guard/phpunit2/version'
 
 module Guard
@@ -7,7 +7,7 @@ module Guard
   # The PHPUnit guard gets notified about system
   # events.
   #
-  class PHPUnit2 < Guard
+  class PHPUnit2 < Plugin
 
     autoload :Inspector, 'guard/phpunit2/inspector'
     autoload :Formatter, 'guard/phpunit2/formatter'

--- a/lib/guard/phpunit2/notifier.rb
+++ b/lib/guard/phpunit2/notifier.rb
@@ -13,7 +13,7 @@ module Guard
         # @param [Hash] options the notifier options
         #
         def notify(message, options)
-          ::Guard::Notifier.notify(message, options)
+          Compat::UI.notify(message, options)
         end
 
         # Displays a notification about the tests results.

--- a/lib/guard/phpunit2/realtime_runner.rb
+++ b/lib/guard/phpunit2/realtime_runner.rb
@@ -40,6 +40,7 @@ module Guard
         end
 
         def execute_phpunit(tests_folder, options)
+	  require 'tempfile'
           log_file = Tempfile.new "guard-phpunit2"
           execute_command(phpunit_command(tests_folder, options, log_file.path))
 

--- a/lib/guard/phpunit2/runner.rb
+++ b/lib/guard/phpunit2/runner.rb
@@ -34,7 +34,7 @@ module Guard
           return false if paths.empty?
 
           unless phpunit_exists?(options)
-            UI.error('the provided php unit command is invalid or phpunit is not installed on your machine.', :reset => true)
+            Compat::UI.error('the provided php unit command is invalid or phpunit is not installed on your machine.', :reset => true)
             return false
           end
 
@@ -100,7 +100,7 @@ module Guard
         #
         def notify_start(paths, options)
           message = options[:message] || "Running: #{paths.join(' ')}"
-          UI.info(message, :reset => true)
+          Compat::UI.info(message, :reset => true)
         end
 
         # Displays a notification about the tests results.

--- a/spec/guard/phpunit2/notifier_spec.rb
+++ b/spec/guard/phpunit2/notifier_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
+require 'guard/phpunit2/notifier'
 
 describe Guard::PHPUnit2::Notifier do
 
-  let(:guard_notifier) { Guard::Notifier }
+  let(:guard_notifier) { Guard::Compat::UI }
 
   describe '.notify' do
     it 'calls the guard notifier' do

--- a/spec/guard/phpunit2/realtime_runner_spec.rb
+++ b/spec/guard/phpunit2/realtime_runner_spec.rb
@@ -5,7 +5,7 @@ describe Guard::PHPUnit2::RealtimeRunner do
   let(:formatter) { Guard::PHPUnit2::Formatter }
   let(:logreader) { Guard::PHPUnit2::LogReader }
   let(:notifier)  { Guard::PHPUnit2::Notifier  }
-  let(:ui)        { Guard::UI                 }
+  let(:ui)        { Guard::Compat::UI          }
 
   describe '#run' do
     before do

--- a/spec/guard/phpunit2/realtime_runner_spec.rb
+++ b/spec/guard/phpunit2/realtime_runner_spec.rb
@@ -21,7 +21,7 @@ describe Guard::PHPUnit2::RealtimeRunner do
 
     context 'when passed an empty paths list' do
       it 'returns false' do
-        subject.run([]).should be_false
+        subject.run([]).should be false
       end
     end
 

--- a/spec/guard/phpunit2/runner_spec.rb
+++ b/spec/guard/phpunit2/runner_spec.rb
@@ -20,7 +20,7 @@ describe Guard::PHPUnit2::Runner do
 
     context 'when passed an empty paths list' do
       it 'returns false' do
-        subject.run([]).should be_false
+        subject.run([]).should be false
       end
     end
 

--- a/spec/guard/phpunit2/runner_spec.rb
+++ b/spec/guard/phpunit2/runner_spec.rb
@@ -4,7 +4,7 @@ describe Guard::PHPUnit2::Runner do
 
   let(:formatter) { Guard::PHPUnit2::Formatter }
   let(:notifier)  { Guard::PHPUnit2::Notifier  }
-  let(:ui)        { Guard::UI                 }
+  let(:ui)        { Guard::Compat::UI          }
 
   describe '#run' do
     before do

--- a/spec/guard/phpunit2_spec.rb
+++ b/spec/guard/phpunit2_spec.rb
@@ -9,15 +9,15 @@ describe Guard::PHPUnit2 do
   describe '#initialize' do
     context 'when no options are provided' do
       it 'sets a default :all_on_start option' do
-        subject.options[:all_on_start].should be_true
+        subject.options[:all_on_start].should be true
       end
 
       it 'sets a default :all_after_pass option' do
-        subject.options[:all_after_pass].should be_true
+        subject.options[:all_after_pass].should be true
       end
 
       it 'sets a default :keep_failed option' do
-        subject.options[:keep_failed].should be_true
+        subject.options[:keep_failed].should be true
       end
 
       it 'sets a default :tests_path option' do
@@ -25,11 +25,11 @@ describe Guard::PHPUnit2 do
       end
 
       it 'sets a default :notification option' do
-        subject.options[:notification].should be_true
+        subject.options[:notification].should be true
       end
 
       it 'sets a default :realtime option' do
-        subject.options[:realtime].should be_false
+        subject.options[:realtime].should be false
       end
     end
 
@@ -43,15 +43,15 @@ describe Guard::PHPUnit2 do
                                           :realtime       => true}) }
 
       it 'sets :all_on_start with the provided option' do
-        subject.options[:all_on_start].should be_false
+        subject.options[:all_on_start].should be false
       end
 
       it 'sets :all_after_pass with the provided option' do
-        subject.options[:all_after_pass].should be_false
+        subject.options[:all_after_pass].should be false
       end
 
       it 'sets :keep_failed with the provided option' do
-        subject.options[:keep_failed].should be_false
+        subject.options[:keep_failed].should be false
       end
 
       it 'sets :cli with the provided option' do
@@ -63,7 +63,7 @@ describe Guard::PHPUnit2 do
       end
 
       it 'sets :realtime with the provided option' do
-        subject.options[:realtime].should be_true
+        subject.options[:realtime].should be true
       end
     end
 
@@ -129,7 +129,7 @@ describe Guard::PHPUnit2 do
 
   describe '#run_on_changes' do
     before do
-      inspector.stub(:clean).and_return { |paths| paths }
+      inspector.stub(:clean) { |paths| paths }
     end
 
     it 'cleans the changed paths before running the tests' do

--- a/spec/guard/phpunit2_spec.rb
+++ b/spec/guard/phpunit2_spec.rb
@@ -35,12 +35,12 @@ describe Guard::PHPUnit2 do
 
     context 'when other options are provided' do
 
-      subject { Guard::PHPUnit2.new(nil, { :all_on_start   => false,
-                                          :all_after_pass => false,
-                                          :keep_failed    => false,
-                                          :cli            => '--colors',
-                                          :tests_path     => 'tests',
-                                          :realtime       => true}) }
+      subject { Guard::PHPUnit2.new({ :all_on_start   => false,
+				      :all_after_pass => false,
+				      :keep_failed    => false,
+				      :cli            => '--colors',
+				      :tests_path     => 'tests',
+				      :realtime       => true}) }
 
       it 'sets :all_on_start with the provided option' do
         subject.options[:all_on_start].should be false
@@ -82,7 +82,7 @@ describe Guard::PHPUnit2 do
     end
 
     context 'with the :all_on_start option set to false' do
-      subject { Guard::PHPUnit2.new(nil, :all_on_start => false) }
+      subject { Guard::PHPUnit2.new(:all_on_start => false) }
 
       it 'calls #run_all' do
         subject.should_not_receive(:run_all)
@@ -110,7 +110,7 @@ describe Guard::PHPUnit2 do
 
   describe 'realtime handling' do
     describe 'realtime endabled' do
-      let(:guard) { Guard::PHPUnit2.new(nil, {:realtime => true }) }
+      let(:guard) { Guard::PHPUnit2.new({:realtime => true }) }
       it 'should call run on the realtimerunner' do
         Guard::PHPUnit2::RealtimeRunner.should_receive(:run).and_return(true)
         guard.run_on_changes ['tests/firstTest.php']
@@ -118,7 +118,7 @@ describe Guard::PHPUnit2 do
     end
 
     describe 'realtime disabled' do
-      let(:guard) { Guard::PHPUnit2.new(nil, {:realtime => false }) }
+      let(:guard) { Guard::PHPUnit2.new({:realtime => false }) }
 
       it 'should call run on the Runner class' do
         Guard::PHPUnit2::Runner.should_receive(:run).and_return(true)
@@ -171,7 +171,7 @@ describe Guard::PHPUnit2 do
       end
 
       context 'with the :keep_failed option set to false' do
-        subject { Guard::PHPUnit2.new(nil, :keep_failed => false) }
+	subject { Guard::PHPUnit2.new(:keep_failed => false) }
 
         it 'runs the next changed files normally without the failed tests' do
           expect { subject.run_on_changes ['tests/firstTest.php'] }.to throw_symbol :task_has_failed
@@ -204,7 +204,7 @@ describe Guard::PHPUnit2 do
       end
 
       context 'with the :all_after_pass option set to false' do
-        subject { Guard::PHPUnit2.new(nil, :all_after_pass => false) }
+	subject { Guard::PHPUnit2.new(:all_after_pass => false) }
 
         it 'does not call #run_all' do
           subject.should_not_receive(:run_all)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.color = true
-  confog.raise_errors_for_deprecations!
+  config.raise_errors_for_deprecations!
   config.filter_run :focus
 
   config.before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,8 @@ RSpec.configure do |config|
 
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
-  config.color_enabled = true
+  config.color = true
+  confog.raise_errors_for_deprecations!
   config.filter_run :focus
 
   config.before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'rspec'
+require 'guard/notifier'
+require 'guard/compat/test/helper'
 require 'guard/phpunit2'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Mostly updates migrating to using `guard-compat` to stub out plugin internals for testing. `Guard::Guard` is no longer available and has been migrated to `Guard::Plugin` as the base class. The initialize signature changed moving watchers into options.