### PR TITLE
Fix LogReader to get a well formatted JSON

### DIFF
--- a/lib/guard/phpunit2/logreader.rb
+++ b/lib/guard/phpunit2/logreader.rb
@@ -53,7 +53,7 @@ module Guard
           # @param [String] json log output from PPHUnit
           #  @return [String] properly-formed JSON string
           def clean_output(output)
-            "[#{output.gsub(/^}{/, '},{')}]"
+            "[#{output.gsub(/}{/, '},{')}]"
           end
 
           # Turns a float duration into a array of integer seconds and the 


### PR DESCRIPTION
The LoagReader didn't generate the commas between the different JSON objects, so the final array was invalid.
