### PR TITLE
Update errors/incomplete regexes

### DIFF
--- a/lib/guard/phpunit2/formatter.rb
+++ b/lib/guard/phpunit2/formatter.rb
@@ -17,8 +17,8 @@ module Guard
           results = {
             :tests    => look_for_words_in('(?:Tests:|tests)',    text),
             :failures => look_for_words_in('(?:Failures:|failures)', text),
-            :errors   => look_for_words_in('Errors:', text),
-            :pending  => look_for_words_in(['(?:Skipped:|skipped)', 'Incomplete:'], text),
+            :errors   => look_for_words_in('(?:Errors:|errors)', text),
+            :pending  => look_for_words_in(['(?:Skipped:|skipped)', '(?:Incomplete:|incomplete)'], text),
             :duration => look_for_duration_in(text)
           }
           results.freeze


### PR DESCRIPTION
While the other formatter parsing options looked for both cases, Errors and Incomplete were
left as only capitalized. As of PHPUnit 4.8 (used for testing this) the Errors and Incomplete
messages are all lower cases, so the formatter was not picking them up and was providing
incorrect information to the terminal-notifier.  This fix adds lower cased versions to the
existing regexes to match the rest of the parsing options.

I've tested it with terminal-notifier on OSX El Capitan, with PHP Unit 4.8, PHP 7.0. There shouldn't be any breaking changes as the regex supports the previous formatting as well as the new.

Possibly a solution for #10 as well.