### PR TITLE
made progress result printer upwards compatible for newer phpunit versions

### DIFF
--- a/lib/guard/phpunit/formatters/PHPUnit-Progress/PHPUnit/Extensions/Progress/ResultPrinter.php
+++ b/lib/guard/phpunit/formatters/PHPUnit-Progress/PHPUnit/Extensions/Progress/ResultPrinter.php
@@ -11,6 +11,13 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @version    0.1
  */
+
+use PHPUnit\TextUI\ResultPrinter as PHPUnit_TextUI_ResultPrinter;
+use PHPUnit\Framework\Test as PHPUnit_Framework_Test;
+use PHPUnit\Framework\TestResult as PHPUnit_Framework_TestResult;
+use PHPUnit\Framework\TestFailure as PHPUnit_Framework_TestFailure;
+use PHPUnit\Framework\AssertionFailedError as PHPUnit_Framework_AssertionFailedError;
+
 class PHPUnit_Extensions_Progress_ResultPrinter extends PHPUnit_TextUI_ResultPrinter {
 
   /**


### PR DESCRIPTION
The progress result printer lead to class not found errors on PHP since the namespaces are underscored instead of backslashed as is the case with newer PHPUnit versions.

Tested with PHPUnit 6.2.3 and PHP 7.0.18